### PR TITLE
Change gremlin-driver version to 3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-driver</artifactId>
-            <version>3.3.1</version>
+            <version>3.3.2</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>


### PR DESCRIPTION
Increasing gremlin-driver version to 3.2.2. We need to decide if after this change we want to bump all the `amazon-neptune-*` to `1.0.2` or only this one.
