### PR TITLE
adding enable ssl option

### DIFF
--- a/src/main/java/com/amazon/neptune/gremlin/driver/example/NeptuneGremlinSigV4Example.java
+++ b/src/main/java/com/amazon/neptune/gremlin/driver/example/NeptuneGremlinSigV4Example.java
@@ -53,6 +53,10 @@ public final class NeptuneGremlinSigV4Example {
      * Command line option name for the db cluster/instance port.
      */
     private static final String PORT = "port";
+    /**
+     * Command line option name for the whether to use ssl connection.
+     */
+    private static final String SSL = "ssl";
 
     /**
      * The gremlin query to test.
@@ -80,6 +84,7 @@ public final class NeptuneGremlinSigV4Example {
 
         //If the neptune db is auth enabled then add use the following channelizer. Otherwise omit the below line.
         builder.channelizer(SigV4WebSocketChannelizer.class);
+        builder.enableSsl(Boolean.parseBoolean(cli.getOptionValue(SSL, "false")));
 
 
         final Cluster cluster = builder.create();
@@ -125,6 +130,11 @@ public final class NeptuneGremlinSigV4Example {
         final Option port = new Option("p", PORT, true, "The db cluster/instance port");
         port.setRequired(true);
         options.addOption(port);
+
+        final Option ssl = new Option("s", SSL, true, "Whether to enable ssl on the connection");
+        ssl.setRequired(false);
+        ssl.setType(Boolean.class);
+        options.addOption(ssl);
 
         return options;
     }


### PR DESCRIPTION
*Issue #, if available:*

I was unable to connect to an iam enabled Neptune graph using the latest version of the graph database - 1.0.2.2.R1. I was following the instructions in the documentation linked in this project;s readme. Once I enabled ssl in the connection properties of the gremlin console conf file for neptune-remote.yaml it started working.  I have submitted a documentation change request.

*Description of changes:*

New optional option of whether to turn on Ssl for the connection to Neptune. Defaults to false so no behaviour changes if callers follow the current documentation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
