### PR TITLE
Add WS compression and bump versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ For example usage refer to:
 
 For the official Amazon Neptune page refer to: https://aws.amazon.com/neptune
 
+## Version
+
+1.x - This series uses TinkerPop 3.3.x client. Note that active maintenance on TinkerPop 3.3.x has stopped and hence, this version is not recommended.
+
+2.x - This series uses TinkerPop 3.4.x client. This major version tracks the latest stable release for this package. Note that a minor version (y in 2.x.y) is bumped whenever a new version of Apache TinkerPop is added as a dependency or a major feature is introduced. All minor versions in 2.x series are backward compatible.
+
+For more information on compatibility with Amazon Neptune engine releases, see https://docs.aws.amazon.com/neptune/latest/userguide/best-practices-gremlin-java-latest.html 
+
 ## License
 
 This library is licensed under the Apache 2.0 License. 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-neptune-gremlin-java-sigv4</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.2</version>
+    <version>2.1.0</version>
 
     <name>amazon-neptune-gremlin-java-sigv4</name>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-neptune-gremlin-java-sigv4</artifactId>
     <packaging>jar</packaging>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
 
     <name>amazon-neptune-gremlin-java-sigv4</name>
     <description>


### PR DESCRIPTION
### Changes
- First commit, bump version to 2.1.0 after upgrade to TP3.4.8 earlier.
- Second commit, bump version 2.1.1 since a new functionality (WS compression) is introduced.

### WS Compression
This functionality has also been added to and tests with OSS TinkerPop: https://github.com/apache/tinkerpop/pull/1344

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
