### PR TITLE
Upgrade TinkerPop to 3.4.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-neptune-gremlin-java-sigv4</artifactId>
     <packaging>jar</packaging>
-    <version>2.1.1</version>
+    <version>2.1.2</version>
 
     <name>amazon-neptune-gremlin-java-sigv4</name>
     <description>
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-driver</artifactId>
-            <version>3.4.8</version>
+            <version>3.4.9</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>
@@ -118,12 +118,12 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>amazon-neptune-sigv4-signer</artifactId>
-            <version>${project.version}</version>
+            <version>2.1.1</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.48.Final</version>
+            <version>4.1.52.Final</version>
         </dependency>
 
         <!-- Test -->

--- a/src/main/java/org/apache/tinkerpop/gremlin/driver/SigV4WebSocketChannelizer.java
+++ b/src/main/java/org/apache/tinkerpop/gremlin/driver/SigV4WebSocketChannelizer.java
@@ -190,7 +190,8 @@ public class SigV4WebSocketChannelizer extends AbstractChannelizer {
         try {
             // Block until the handshake is complete either successfully or with an error. The handshake future
             // will complete with a timeout exception after some time so it is guaranteed that this future will
-            // complete.
+            // complete. The timeout for the handshake is configured by cluster.getConnectionSetupTimeout().
+            //
             // If future completed with an exception more than likely, SSL is enabled on the server, but the client
             // forgot to enable it or perhaps the server is not configured for websockets.
             handler.handshakeFuture().sync();

--- a/src/main/java/org/apache/tinkerpop/gremlin/driver/SigV4WebSocketChannelizer.java
+++ b/src/main/java/org/apache/tinkerpop/gremlin/driver/SigV4WebSocketChannelizer.java
@@ -198,6 +198,11 @@ public class SigV4WebSocketChannelizer extends AbstractChannelizer {
         } catch (Exception ex) {
             String errMsg = "";
             if (ex instanceof TimeoutException) {
+                // Note that we are not using catch(TimeoutException ex) because the compiler throws an error for
+                // catching a checked exception which is not thrown from the code inside try. However, the compiler
+                // check is incorrect since Netty bypasses the compiler check and sync() is able to rethrow underlying
+                // exception even if it is a check exception.
+                // More information about how Netty bypasses compiler check at https://github.com/netty/netty/blob/d371b1bbaa3b98f957f6b025673098ad3adb5131/common/src/main/java/io/netty/util/internal/PlatformDependent.java#L418
                 errMsg = "Timed out while waiting to complete the connection setup. Consider increasing the " +
                         "WebSocket handshake timeout duration.";
             } else {


### PR DESCRIPTION
*Issue #:* https://github.com/aws/amazon-neptune-gremlin-java-sigv4/issues/29

*Description of changes:*
- Upgrade TinkerPop dependency to use 3.4.9
- Upgrade Netty version to 4.1.52
- Minor changes in code associated with upgrade to 3.4.9

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

*Testing:*
- Verified sanity of the client by testing against Neptune Server.
