### PR TITLE
Undo update of TinkerPop to 3.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-driver</artifactId>
-            <version>3.5.0</version>
+            <version>3.4.10</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>

--- a/src/main/java/org/apache/tinkerpop/gremlin/driver/SigV4WebSocketChannelizer.java
+++ b/src/main/java/org/apache/tinkerpop/gremlin/driver/SigV4WebSocketChannelizer.java
@@ -46,6 +46,7 @@ import io.netty.handler.codec.http.EmptyHttpHeaders;
 import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
 import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketClientCompressionHandler;
@@ -130,6 +131,20 @@ public class SigV4WebSocketChannelizer extends AbstractChannelizer {
         super.init(connection);
         webSocketGremlinRequestEncoder = new WebSocketGremlinRequestEncoder(true, cluster.getSerializer());
         webSocketGremlinResponseDecoder = new WebSocketGremlinResponseDecoder(cluster.getSerializer());
+    }
+
+    /**
+     * Keep-alive is supported through the ping/pong websocket protocol.
+     * @see <a href=https://tools.ietf.org/html/rfc6455#section-5.5.2>IETF RFC 6455</a>
+     */
+    @Override
+    public boolean supportsKeepAlive() {
+        return true;
+    }
+
+    @Override
+    public Object createKeepAliveMessage() {
+        return new PingWebSocketFrame();
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:* NEPTUNE-40575

*Description of changes:* TinkerPop version 3.5 is not officially supported yet.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
