### PR TITLE
Bump to 2.4.0 for release.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-neptune-gremlin-java-sigv4</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.1</version>
+    <version>2.4.0</version>
 
     <name>amazon-neptune-gremlin-java-sigv4</name>
     <description>


### PR DESCRIPTION
*Description of changes:*

Bumped the release version to 2.4.0 which aligns with related sigv4 libs along TinkerPop 3.4.10.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
