### PR TITLE
Bump to TinkerPop 3.5.1 which increments the package to 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ For the official Amazon Neptune page refer to: https://aws.amazon.com/neptune
 
 2.x - This series uses TinkerPop 3.4.x client. This major version tracks the latest stable release for this package. Note that a minor version (y in 2.x.y) is bumped whenever a new version of Apache TinkerPop is added as a dependency or a major feature is introduced. All minor versions in 2.x series are backward compatible.
 
+3.x - This series uses TinkerPop 3.5.x client. This version is present for legacy continuity reasons as starting with 2.4.0 (which uses TinkerPop 3.4.11) use of the `HandshakeInterceptor` in `gremlin-driver` is the preferred method for sigv4 signing as discussed [here](https://docs.aws.amazon.com/neptune/latest/userguide/iam-auth-connecting-gremlin-java.html#iam-auth-connecting-gremlin-java-current).
+
 For more information on compatibility with Amazon Neptune engine releases, see [Use the Latest Version of the Gremlin Java Client](https://docs.aws.amazon.com/neptune/latest/userguide/best-practices-gremlin-java-latest.html). 
 
 ## License

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-neptune-gremlin-java-sigv4</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.0</version>
+    <version>3.0.0</version>
 
     <name>amazon-neptune-gremlin-java-sigv4</name>
     <description>
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-driver</artifactId>
-            <version>3.4.10</version>
+            <version>3.5.1</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>amazon-neptune-sigv4-signer</artifactId>
-            <version>${project.version}</version>
+            <version>2.4.0</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/src/main/java/org/apache/tinkerpop/gremlin/driver/SigV4WebSocketChannelizer.java
+++ b/src/main/java/org/apache/tinkerpop/gremlin/driver/SigV4WebSocketChannelizer.java
@@ -134,20 +134,6 @@ public class SigV4WebSocketChannelizer extends AbstractChannelizer {
     }
 
     /**
-     * Keep-alive is supported through the ping/pong websocket protocol.
-     * @see <a href=https://tools.ietf.org/html/rfc6455#section-5.5.2>IETF RFC 6455</a>
-     */
-    @Override
-    public boolean supportsKeepAlive() {
-        return true;
-    }
-
-    @Override
-    public Object createKeepAliveMessage() {
-        return new PingWebSocketFrame();
-    }
-
-    /**
      * Sends a {@code CloseWebSocketFrame} to the server for the specified channel.
      */
     @Override


### PR DESCRIPTION
Bumped the release version to 3.0.0 and to TinkerPop 3.5.1. This 3.x version is really only for continuity purposes on the way to 3.5.1 as users should now prefer using the handshake interceptor as of TinkerPop 3.4.11. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
