### PR TITLE
Update netty-all version to latest 4.1.79.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-neptune-gremlin-java-sigv4</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.0</version>
+    <version>2.4.1</version>
 
     <name>amazon-neptune-gremlin-java-sigv4</name>
     <description>
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.63.Final</version>
+            <version>4.1.79.Final</version>
         </dependency>
 
         <!-- Test -->


### PR DESCRIPTION
*Issue #, if available:* Warning:(49, 20)  Provides transitive vulnerable dependency io.netty:netty-all:4.1.73.Final CVE-2022-24823 5.5 Exposure of Resource to Wrong Sphere vulnerability pending CVSS allocation  Results powered by Checkmarx(c) 

*Description of changes:*
Upgraded the netty-all dependency

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
